### PR TITLE
Point only to dev

### DIFF
--- a/webportal/webapp/src/app/account/loginsync/components/loginsync.component.ts
+++ b/webportal/webapp/src/app/account/loginsync/components/loginsync.component.ts
@@ -36,8 +36,7 @@ export class LoginSyncComponent implements OnInit {
   }
 
   buildRedirectUrl(): string {
-    const env = environment.production ? 'prod' : 'dev';
-    const url = `https://${env}-sdc-dot-webportal.auth.${environment.REGION}` +
+    const url = `https://dev-sdc-dot-webportal.auth.${environment.REGION}` +
                 `.amazoncognito.com/oauth2/authorize?redirect_uri=${environment.REDIRECT_URL}` +
                 `&response_type=token&client_id=${environment.LOGIN_GOV_COGNITO_APP_CLIENT_ID}`;
     return url;


### PR DESCRIPTION
Unfortunately there is a bug on the backend webportal where the cognito user pool is hardcoded to dev. Therefore we need to do the same on the front end.