### PR TITLE
Add missing bucket

### DIFF
--- a/terraform/config/ecs-prod.tfvars
+++ b/terraform/config/ecs-prod.tfvars
@@ -13,5 +13,6 @@ lambda_trigger_buckets = [ "prod-sdc-wydot-004118380849",
                            "prod-sdc-fta-004118380849",
                            "prod-sdc-waze-autoexport-004118380849",
                            "prod-sdc-wydot-autoexport-004118380849",
-                           "prod-sdc-sdi-004118380849" ]
+                           "prod-sdc-sdi-004118380849",
+                           "prod-sdc-cveval-004118380849" ]
 


### PR DESCRIPTION
We were missing a bucket to trigger the S3 metadata lambda.