### PR TITLE
Try and update the dynamo capacity

### DIFF
--- a/terraform/webportal_dynamo_tables.tf
+++ b/terraform/webportal_dynamo_tables.tf
@@ -112,7 +112,7 @@ resource "aws_dynamodb_table" "trusted_users_table" {
 resource "aws_dynamodb_table" "request_export_table" {
   name           = "${local.mismatch_deploy_env}-RequestExportTable"
   billing_mode   = "PROVISIONED"
-  read_capacity  = 5
+  read_capacity  = 15
   write_capacity = 5
   hash_key       = "S3KeyHash"
   range_key      = "RequestedBy_Epoch"


### PR DESCRIPTION
### JIRA Ticket

N/A bug fix

### Summary

We were periodically seeing this in the logs:
```(ProvisionedThroughputExceededException) when calling the Scan operation (reached max retries: 9): The level of configured provisioned throughput for the table was exceeded. Consider increasing your provisioning level with the UpdateTable API```
This bumps up the throughput on Dynamo so that dynamo S3 metdata queries succeed.